### PR TITLE
 Devices: fsl: mf0300_6dq: define shift4 app data file

### DIFF
--- a/mf0300_6dq/sepolicy/file.te
+++ b/mf0300_6dq/sepolicy/file.te
@@ -1,2 +1,5 @@
 type sysfs_i2c, fs_type, sysfs_type;
 type serialnumber_socket, file_type;
+
+# Shift4 apps files
+type shift4_app_data_file, file_type, data_file_type, mlstrustedobject;

--- a/mf0300_6dq/sepolicy/seapp_contexts
+++ b/mf0300_6dq/sepolicy/seapp_contexts
@@ -1,0 +1,2 @@
+# shift4 selinux app domain context file type
+user=_app seinfo=shift4 domain=shift4_app type=shift4_app_data_file


### PR DESCRIPTION
Requaried for Shift4 selinux app domain context file type definition
mlstrustedobject = trusted object (an object for which the mls policy
does not apply - an subject can access it).

Assigns labels to Shift4 signed app processes and /data/data directories.
This configuration is read by the zygote process on each app launch and
by installd during startup.